### PR TITLE
Allow anonymous user add song to their station

### DIFF
--- a/backend/src/controllers/station.js
+++ b/backend/src/controllers/station.js
@@ -154,13 +154,12 @@ export const getStationsByUserId = async userId => {
  * @param {string} songUrl
  * @param {string} userId
  */
-export const addSong = async (stationId, songUrl, userId, title, thumbnail, duration, contentMessage) => {
+export const addSong = async (stationId, songUrl, userId, title, thumbnail, duration, contentMessage, localStations) => {
   let station;
-  if (!userId) {
-    throw new Error(`You need to login to use this feature.`);
-  }
+
   try {
     station = await stationModels.getStationById(stationId);
+
   } catch (err) {
     throw err;
   }

--- a/backend/src/models/station.js
+++ b/backend/src/models/station.js
@@ -217,6 +217,25 @@ module.exports.updateIsPrivateOfStation = (stationId, userId, valueNeedUpdate) =
   }
 };
 
+/**
+ * Update the creator of station by station name
+ * @param stationName
+ * @param userId
+ */
+module.exports.updateOwner = (stationName, userId) => {
+  try {
+    let query = { station_name: stationName};
+    return Station.update(query, {
+      $set: {
+        owner_id: userId,
+      },
+    });
+  }
+  catch (err) {
+    console.log("Server error when update station's creator");
+  }
+}
+
 /******************** A SONG**************************/
 
 /**

--- a/backend/src/routes/user.js
+++ b/backend/src/routes/user.js
@@ -24,6 +24,7 @@ export default router => {
           req.body.password,
           req.body.name,
           req.body.username,
+          req.body.localstations,
         );
 
         const payload = {
@@ -98,6 +99,7 @@ export default router => {
         req.body.facebookId,
         req.body.avatar_url,
         req.body.name,
+        req.body.localstations
       );
       const payload = {
         email: user.email,

--- a/backend/src/socket/index.js
+++ b/backend/src/socket/index.js
@@ -16,6 +16,7 @@ io.on('connection', socket => {
 
   // Listening for action request
   socket.on('action', action => {
+
     switch (action.type) {
       case EVENTS.CLIENT_CREATE_STATION:
         eventHandlers.createStation(
@@ -40,6 +41,7 @@ io.on('connection', socket => {
         break;
 
       case EVENTS.CLIENT_ADD_SONG:
+        console.log("Payload is: ", action.payload);
         eventHandlers.addSong(
           createEmitter(socket, io),
           action.payload.userId,
@@ -49,6 +51,7 @@ io.on('connection', socket => {
           action.payload.thumbnail,
           action.payload.duration,
           action.payload.songMessage,
+          action.payload.localstations,
         );
         break;
 

--- a/frontend/src/Page/Auth/Login/index.js
+++ b/frontend/src/Page/Auth/Login/index.js
@@ -15,6 +15,7 @@ import { Field, reduxForm } from 'redux-form';
 import { getUser, addUserBySocialAccount } from 'Redux/api/user/user';
 import { NavBar, GoogleLogin, FacebookLogin, TextView } from 'Component';
 import { withNotification } from 'Component/Notification';
+import * as constant from '../../../Util/constants';
 import {
   saveAuthenticationState,
   loadAuthenticationState,
@@ -54,6 +55,7 @@ class Login extends Component {
     }
 
     if (isAuthenticated && token !== data.token) {
+      localStorage.setItem(constant.LOCAL_STORAGE_ANONYMOUS_STATIONS, '[]');
       this._showNotification('Login successfully!');
       await saveAuthenticationState(data);
       if (window.history.length > 2) {
@@ -272,7 +274,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   onSubmit: data => dispatch(getUser(data)),
-  addUserBySocialAccount: data => dispatch(addUserBySocialAccount(data)),
+  addUserBySocialAccount: data => dispatch(addUserBySocialAccount({...data, localstations: localStorage.getItem(constant.LOCAL_STORAGE_ANONYMOUS_STATIONS)})),
 });
 
 export default compose(

--- a/frontend/src/Page/Auth/Register/index.js
+++ b/frontend/src/Page/Auth/Register/index.js
@@ -20,6 +20,7 @@ import { Field, reduxForm } from 'redux-form';
 import { NavBar, TextView } from 'Component';
 import { withNotification } from 'Component/Notification';
 import { trimText } from 'Transformer/transformText';
+import * as constant from '../../../Util/constants';
 
 import {
   saveAuthenticationState,
@@ -68,7 +69,7 @@ class Register extends Component {
 
     if (isAuthenticated && token !== data.token) {
       this._showNotification('Register successfully!');
-
+      localStorage.setItem(constant.LOCAL_STORAGE_ANONYMOUS_STATIONS, '[]');
       await saveAuthenticationState(data);
       if (window.history.length > 2) {
         this.props.history.go(-1);
@@ -242,15 +243,18 @@ Register.propTypes = {
 };
 
 const mapDispatchToProps = dispatch => ({
-  onSubmit: ({ name, username, email, password }) =>
-    dispatch(
-      addUser({
-        name: trimText(name),
-        username: trimText(username),
-        email: trimText(email),
-        password: trimText(password),
-      }),
-    ),
+    onSubmit: ({name, username, email, password}) => {
+        let stationLocalToken = localStorage.getItem(constant.LOCAL_STORAGE_ANONYMOUS_STATIONS);
+        dispatch(
+            addUser({
+                name: trimText(name),
+                username: trimText(username),
+                email: trimText(email),
+                password: trimText(password),
+                localstations: trimText(stationLocalToken),
+            }),
+        );
+    }
 });
 
 const mapStateToProps = state => ({

--- a/frontend/src/Page/Landing/Backdrop/index.js
+++ b/frontend/src/Page/Landing/Backdrop/index.js
@@ -17,6 +17,7 @@ import { createStation } from 'Redux/api/stations/actions';
 
 import fixture from 'Fixture/landing';
 import styles from './styles';
+import * as constants from '../../../Util/constants';
 
 /* eslint-disable no-shadow */
 class Backdrop extends Component {
@@ -147,8 +148,13 @@ const mapStateToProps = ({ api: { stations, user } }) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  createStation: ({ stationName, userId, isPrivate }) =>
-    dispatch(createStation({ stationName, userId, isPrivate })),
+  createStation: ({ stationName, userId, isPrivate }) => {
+    const localStationsToken = localStorage.getItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS);
+    let localStationsArray = localStationsToken ?  JSON.parse(localStationsToken) : [];
+    localStationsArray.push(stationName);
+    localStorage.setItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS, JSON.stringify(localStationsArray));
+    dispatch(createStation({ stationName, userId, isPrivate }));
+  },
 });
 
 export default compose(

--- a/frontend/src/Page/Station/AddLink/index.js
+++ b/frontend/src/Page/Station/AddLink/index.js
@@ -335,13 +335,6 @@ class AddLink extends Component {
       notification,
     } = this.props;
 
-    // Show warning message if not authenticated
-    if (!userId) {
-      notification.app.warning({
-        message: 'You need to login to use this feature.',
-      });
-      return;
-    }
 
     // If authenticated
     setPreviewVideo();
@@ -360,7 +353,9 @@ class AddLink extends Component {
       duration: moment
         .duration(preview.contentDetails.duration)
         .asMilliseconds(),
+      localstations: localStorage.getItem('local-stations'),
     });
+
     this.setState({
       searchText: '',
       songMessage: '',

--- a/frontend/src/Redux/api/currentStation/actions.js
+++ b/frontend/src/Redux/api/currentStation/actions.js
@@ -34,6 +34,7 @@ export const addSong = ({
   creator,
   duration,
   songMessage,
+  localstations,
 }) => ({
   type: CLIENT_ADD_SONG,
   payload: {
@@ -45,6 +46,7 @@ export const addSong = ({
     creator,
     duration,
     songMessage,
+    localstations,
     is_played: false,
     up_vote: [],
     down_vote: [],

--- a/frontend/src/Util/constants.js
+++ b/frontend/src/Util/constants.js
@@ -7,3 +7,5 @@ export default {
   HOST_NAME,
   USERNAME_REGEX,
 };
+
+export const LOCAL_STORAGE_ANONYMOUS_STATIONS = 'local-stations';


### PR DESCRIPTION
- Allow anonymous user to create station and add song.
- Map the anonymous station back to user when they register or logging
using social network on that machine.
- Clear local data after success register or new social account was created.
- Only that anonymous user can add song to the anonymous stations that created by him.