### PR TITLE
fix_bug_anonymous_station_name_id

### DIFF
--- a/backend/src/controllers/user.js
+++ b/backend/src/controllers/user.js
@@ -419,7 +419,6 @@ async function _createUserWithSocialAccount(email, googleId, facebookId, avatar_
     await user.save();
     const username = await _createUsername(name);
     await userModels.setUsername(email, username);
-
     if (avatar_url) {
         await userModels.setAvatarUrl(email, avatar_url);
         await _increaseReputation(email, 20)

--- a/frontend/src/Page/Landing/Backdrop/index.js
+++ b/frontend/src/Page/Landing/Backdrop/index.js
@@ -44,6 +44,10 @@ class Backdrop extends Component {
 
     // Redirect to the created station page
     if (station && station.station_id) {
+        const localStationsToken = localStorage.getItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS);
+        let localStationsArray = localStationsToken ?  JSON.parse(localStationsToken) : [];
+        localStationsArray.push(station.station_id);
+        localStorage.setItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS, JSON.stringify(localStationsArray));
       history.replace(`/station/${station.station_id}`);
     }
   }
@@ -149,10 +153,6 @@ const mapStateToProps = ({ api: { stations, user } }) => ({
 
 const mapDispatchToProps = dispatch => ({
   createStation: ({ stationName, userId, isPrivate }) => {
-    const localStationsToken = localStorage.getItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS);
-    let localStationsArray = localStationsToken ?  JSON.parse(localStationsToken) : [];
-    localStationsArray.push(stationName);
-    localStorage.setItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS, JSON.stringify(localStationsArray));
     dispatch(createStation({ stationName, userId, isPrivate }));
   },
 });

--- a/frontend/src/Page/Landing/Backdrop/index.js
+++ b/frontend/src/Page/Landing/Backdrop/index.js
@@ -48,7 +48,7 @@ class Backdrop extends Component {
         let localStationsArray = localStationsToken ?  JSON.parse(localStationsToken) : [];
         localStationsArray.push(station.station_id);
         localStorage.setItem(constants.LOCAL_STORAGE_ANONYMOUS_STATIONS, JSON.stringify(localStationsArray));
-      history.replace(`/station/${station.station_id}`);
+        history.replace(`/station/${station.station_id}`);
     }
   }
 


### PR DESCRIPTION
Fix the bug happen when having anonymous station name with same content but differ in cap.
For example:
- Create station: name: sa1 -> stationId = sa1
- Create station: name: Sa1 -> stationId - sa11
It can cause trouble when we remap the anonymous stations to user.
In the old code, the stationName were used to stores the anonymos stations in local, now we use stationId